### PR TITLE
unpack, path and an error message update

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import json
 import os
 import discord
 from discord_slash import SlashCommand
-from discord_slash.utils.manage_commands import create_option
+from discord_slash.utils.manage_commands import create_option, create_choice
 
 client = discord.Client(intents=discord.Intents.all())
 slash = SlashCommand(client, sync_commands=True)


### PR DESCRIPTION
unpack now lowers the search term too as oppose to only the string for which we are iterating now
print error message of ctx.sending when fallback doesn't work will now output the result too as opposed to "something happened" type of error (so it prints out actual information)
the path type searcher was created! it now figures out if the path its getting from system is / or \ and takes action accordingly